### PR TITLE
feat: numpy.typing.NDArray requires >=1.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7.1,<3.11"
 attrs = ">=19.0"
-numpy = "^1.20"
+numpy = "^1.21"
 scipy = "^1.6"
 typing-extensions = { version = "^4", python = "~3.7" }
 


### PR DESCRIPTION
BREAKING CHANGE: bumped min numpy version

## Affected Issues
<!--
Please list issues affected by this PR.
-->
- Fixes #

## Proposed Changes
<!--
Please explain what was changed in this PR.
-->
-
